### PR TITLE
Us446 update parallel test executor plugin to fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jenkins:2.60.1
+FROM jenkinsci/jenkins:2.60.3
 
 # skip the setup wizard
 ENV JAVA_ARGS -Djenkins.install.runSetupWizard=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV JAVA_ARGS -Djenkins.install.runSetupWizard=false
 RUN mkdir -p /usr/share/jenkins/ref/jobs/seed-job
 COPY seedJob.xml /usr/share/jenkins/ref/jobs/seed-job/config.xml
 
+# install fork of parallel-test-executor plugin
+RUN mkdir -p /usr/share/jenkins/ref/plugins/ && wget https://github.com/StephenKing/parallel-test-executor-plugin/releases/download/1.10-SNAPSHOT-JENKINS-46028-primary-job-fallback-1/parallel-test-executor.hpi -O /usr/share/jenkins/ref/plugins/parallel-test-executor.jpi
 
 # install plugins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,7 +1,7 @@
 ec2:1.36
-github-branch-source:2.0.8
+github-branch-source:2.2.3
 job-dsl:1.64
-pipeline-maven:2.5.0
+pipeline-maven:2.5.2
 timestamper:1.8.8
 workflow-aggregator:2.5
 parameterized-trigger:2.35.1

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,7 +1,6 @@
 ec2:1.36
 github-branch-source:2.0.8
 job-dsl:1.64
-parallel-test-executor:1.9
 pipeline-maven:2.5.0
 timestamper:1.8.8
 workflow-aggregator:2.5

--- a/plugins.txt
+++ b/plugins.txt
@@ -4,3 +4,4 @@ job-dsl:1.64
 pipeline-maven:2.5.0
 timestamper:1.8.8
 workflow-aggregator:2.5
+parameterized-trigger:2.35.1


### PR DESCRIPTION
We implemented fallback to the master branch in jenkinsci/parallel-test-executor-plugin#26.
Until this is merged, we need to use our own fork from [JENKINS-46028-primary-job-fallback](https://github.com/StephenKing/parallel-test-executor-plugin/tree/JENKINS-46028-primary-job-fallback) ([artifact](https://github.com/StephenKing/parallel-test-executor-plugin/releases/tag/1.10-SNAPSHOT-JENKINS-46028-primary-job-fallback-1)).

